### PR TITLE
Add ChatterBox Turbo TTS model

### DIFF
--- a/freeze.txt
+++ b/freeze.txt
@@ -284,3 +284,4 @@ yarl==1.9.4
 yt-dlp==2023.12.30
 zipp==3.17.0
 -e git+https://github.com/huggingface/parler-tts.git#egg=parler-tts
+chatterbox-tts==0.1.6

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from openvoicechat.tts.tts_xtts import Mouth_xtts
+from openvoicechat.tts.tts_chatterbox import mouth_ChatterBox
 from openvoicechat.llm.llm_ollama import Chatbot_ollama
 from openvoicechat.stt.stt_hf import Ear_hf
 from openvoicechat.utils import run_chat
@@ -29,7 +29,7 @@ if __name__ == "__main__":
 
     chatbot = Chatbot_ollama(sys_prompt=llama_sales, model="qwen2:0.5b")
 
-    mouth = Mouth_xtts(device=device)
+    mouth = mouth_ChatterBox(device=device)
 
     run_chat(
         mouth, ear, chatbot, verbose=True, stopping_criteria=lambda x: "[END]" in x

--- a/openvoicechat/tts/tts_chatterbox.py
+++ b/openvoicechat/tts/tts_chatterbox.py
@@ -1,0 +1,33 @@
+import torchaudio as ta
+import torch
+from chatterbox.tts_turbo import ChatterboxTurboTTS
+if __name__ == "__main__":
+    from .base import BaseMouth
+else:
+    from .base import BaseMouth
+from dotenv import load_dotenv
+import sounddevice as sd
+import numpy as np
+load_dotenv()
+
+class mouth_ChatterBox(BaseMouth):
+    def __init__(
+        self,
+        device="cuda",
+        speaker=None,
+        wait=True,
+        player=sd,
+        logger=None,
+    ):
+        self.device = device
+        self.model = ChatterboxTurboTTS.from_pretrained(device=self.device)
+
+    def run_tts(self,text,audio_prompt_path):
+        return self.model.generate(text,audio_prompt_path=audio_prompt_path)
+        
+if __name__ == "__main__":
+    tts = mouth_ChatterBox(device="cuda")
+    text = "Hi there, John here from MochaFone calling you back [chuckle], have you got one minute to chat about the billing issue?"
+    wav = tts.run_tts(text, audio_prompt_path="data/refs/harvard.wav")
+    ta.save("test-turbo.wav", wav, tts.model.sr)
+

--- a/openvoicechat/tts/tts_chatterbox.py
+++ b/openvoicechat/tts/tts_chatterbox.py
@@ -1,10 +1,14 @@
 import torchaudio as ta
 import torch
 from chatterbox.tts_turbo import ChatterboxTurboTTS
-if __name__ == "__main__":
+import sys
+from pathlib import Path
+try:
     from .base import BaseMouth
-else:
-    from .base import BaseMouth
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent))
+    from base import BaseMouth
+
 from dotenv import load_dotenv
 import sounddevice as sd
 import numpy as np
@@ -19,15 +23,23 @@ class mouth_ChatterBox(BaseMouth):
         player=sd,
         logger=None,
     ):
+        
         self.device = device
         self.model = ChatterboxTurboTTS.from_pretrained(device=self.device)
+        self.model.prepare_conditionals("data/refs/harvard.wav")
 
-    def run_tts(self,text,audio_prompt_path):
-        return self.model.generate(text,audio_prompt_path=audio_prompt_path)
-        
+    def run_tts(self, text, audio_prompt_path=None):
+        wav_tensor = self.model.generate(text)
+        # Ensure wav_tensor is 2D (channels, samples)
+        if wav_tensor.dim() == 1:
+            wav_tensor = wav_tensor.unsqueeze(0)
+        # Convert to numpy array and transpose to (samples, channels) for sounddevice
+        wav_np = wav_tensor.cpu().numpy().T
+        return wav_np
+    
 if __name__ == "__main__":
     tts = mouth_ChatterBox(device="cuda")
     text = "Hi there, John here from MochaFone calling you back [chuckle], have you got one minute to chat about the billing issue?"
-    wav = tts.run_tts(text, audio_prompt_path="data/refs/harvard.wav")
-    ta.save("test-turbo.wav", wav, tts.model.sr)
+    wav = tts.run_tts(text)
+    ta.save("test-turbo.wav", torch.from_numpy(wav.T), tts.model.sr)
 


### PR DESCRIPTION
- Added a new TTS model ChatterBox Turbo in openvoicechat/tts/tts_chatterbox.py.
- Implemented mouth_ChatterBox class for the model, inheriting from BaseMouth.
- Updated main.py to use the new ChatterBox TTS model.
updates for 12 Jan:
- conditionals are now __init__ function
- run_tts now returns a numpy array 